### PR TITLE
feat: free up alt

### DIFF
--- a/src/cappasity3d.php
+++ b/src/cappasity3d.php
@@ -90,7 +90,7 @@ class Cappasity3d extends Module
         $result = $this->dbManager->setUp()
             && parent::install()
             && $this->installTab()
-            && $this->registerHook('header')
+            && $this->registerHook('displayHeader')
             && $this->registerHook('actionProductUpdate')
             && $this->registerHook('actionProductAdd')
             && $this->registerHook('displayAdminProductsExtra');
@@ -397,7 +397,7 @@ class Cappasity3d extends Module
     /**
      * @return string
      */
-    public function hookHeader()
+    public function hookDisplayHeader()
     {
         $this->context->controller->addCSS($this->local_path . 'views/css/cappasity.css');
 
@@ -407,7 +407,10 @@ class Cappasity3d extends Module
             $this->context->controller->addJS($this->local_path . 'views/js/cappasity16.js');
         }
 
-        return $this->getPlayerSettingDiv();
+        return join('', [
+            $this->getPlayerSettingDiv(),
+            $this->getSyncedImagesDiv()
+        ]);
     }
 
     /**
@@ -438,6 +441,24 @@ class Cappasity3d extends Module
         }
 
         return '';
+    }
+
+    /**
+     * @return string
+     */
+    public function getSyncedImagesDiv()
+    {
+        $productId = Tools::getValue('id_product');
+
+        if (!$productId) {
+            return '';
+        }
+
+        $this->context->smarty->assign(
+            array('syncedImages' => $this->dbManager->getCappasity(['productId' => $productId]))
+        );
+
+        return $this->context->smarty->fetch($this->local_path . 'views/templates/front/synced-images.tpl');
     }
 
     /**

--- a/src/cappasity3d.php
+++ b/src/cappasity3d.php
@@ -407,10 +407,8 @@ class Cappasity3d extends Module
             $this->context->controller->addJS($this->local_path . 'views/js/cappasity16.js');
         }
 
-        return join('', [
-            $this->getPlayerSettingDiv(),
-            $this->getSyncedImagesDiv()
-        ]);
+        return $this->getPlayerSettingDiv()
+            . $this->getSyncedImagesDiv();
     }
 
     /**

--- a/src/override/controllers/front/ProductController.php
+++ b/src/override/controllers/front/ProductController.php
@@ -9,7 +9,7 @@
 class ProductController extends ProductControllerCore
 {
     /**
-     * @TODO legacy block, prestashop could not remove those constans on uninstal
+     * @TODO legacy block, prestashop could not remove those constants on uninstall
      */
     const IMAGE_ID = 1000000000;
     const IMAGE_LEGEND = 'cappasity-preview';
@@ -69,7 +69,6 @@ class ProductController extends ProductControllerCore
      */
     protected function groupByCappasityImage(array $images = array())
     {
-        $counter = 100000000;
         $cappasityImages = array();
 
         foreach ($images as $image) {
@@ -77,7 +76,7 @@ class ProductController extends ProductControllerCore
             $variantId = (string)$image['variant_id'];
 
             if (array_key_exists($cappasityId, $cappasityImages) === false) {
-                $imageId = (string)$counter += 1;
+                $imageId = (string)$this->getMockedImageId($image['id']);
                 $cappasityImages[$cappasityId] = array(
                   'cappasityId' => $cappasityId,
                   'imageId' => $imageId,
@@ -96,13 +95,12 @@ class ProductController extends ProductControllerCore
      */
     protected function groupByVariant(array $images = array())
     {
-        $counter = 100000000;
         $cappasityImages = array();
 
         foreach ($images as $image) {
             $cappasityId = (string)$image['cappasity_id'];
             $variantId = (string)$image['variant_id'];
-            $imageId = (string)$counter += 1;
+            $imageId = (string)$this->getMockedImageId($image['id']);
 
             if (array_key_exists($variantId, $cappasityImages) === false) {
                 $cappasityImages[$variantId] = array();
@@ -204,11 +202,8 @@ class ProductController extends ProductControllerCore
         foreach ($groupedByCappasityImage as $cappasityImage) {
             $imageId = (string)$cappasityImage['imageId'];
             $variantsIds = $cappasityImage['variants'];
-            $cappasityId = (string)$cappasityImage['cappasityId'];
-            $legend = "cappasity:{$cappasityId}";
             // add on top of all pictures
             $images = array($imageId => array(
-                'legend' => $legend,
                 'cover' => '0',
                 'id_image' => $imageId,
                 'position' => $imageId,
@@ -232,7 +227,6 @@ class ProductController extends ProductControllerCore
                 array_unshift($combinationImages[$variantId], array(
                      'id_product_attribute' => $variantId,
                      'id_image' => $imageId,
-                     'legend' => $legend,
                 ));
             }
         }
@@ -299,5 +293,13 @@ class ProductController extends ProductControllerCore
                 array('0')
             )),
         );
+    }
+
+    private function getMockedImageId($originalId)
+    {
+        // todo: move to constant? move to placeholder & use placeholder in js? leave like that?
+        $initialFakeId = 100000000;
+
+        return $initialFakeId + $originalId;
     }
 }

--- a/src/override/controllers/front/ProductController.php
+++ b/src/override/controllers/front/ProductController.php
@@ -156,13 +156,10 @@ class ProductController extends ProductControllerCore
 
             foreach ($cappasityVariantImages as $cappasityVariantImage) {
                 $imageId = (string)$cappasityVariantImage['imageId'];
-                $cappasityId = (string)$cappasityVariantImage['cappasityId'];
-                $legend = "cappasity:{$cappasityId}";
 
                 array_unshift($combinationImages[$productVariantId], array(
                     'id_product_attribute' => $productVariantId,
                     'id_image' => $imageId,
-                    'legend' => $legend,
                 ));
             }
         }
@@ -271,7 +268,6 @@ class ProductController extends ProductControllerCore
     {
         $imageId = (string)$image['imageId'];
         $cappasityId = (string)$image['cappasityId'];
-        $legend = "cappasity:{$cappasityId}";
 
         return array(
             'bySize' => array(
@@ -284,7 +280,6 @@ class ProductController extends ProductControllerCore
             'small' => $this->getImageStub(),
             'medium' => $this->getImage($cappasityId, 452, 452),
             'large' => $this->getImage($cappasityId, 800, 800),
-            'legend' => $legend,
             'cover' => '0',
             'id_image' => $imageId,
             'position' => $imageId,
@@ -297,7 +292,6 @@ class ProductController extends ProductControllerCore
 
     private function getMockedImageId($originalId)
     {
-        // todo: move to constant? move to placeholder & use placeholder in js? leave like that?
         $initialFakeId = 100000000;
 
         return $initialFakeId + $originalId;

--- a/src/views/js/cappasity16.js
+++ b/src/views/js/cappasity16.js
@@ -9,7 +9,7 @@ $(document).ready(function () {
   var previewFilters = 'w80-h80-cpad-bffffff';
   var iconHref = '/modules/cappasity3d/views/img/logo-3d.jpg';
   var iconBigHref = '/modules/cappasity3d/views/img/logo-3d-thickbox.jpg';
-  var megaNumber = 100000000;
+  var initialFakeId = 100000000;
   var playerSettings = $('#' + settingsId).data('embed');
   var syncedImages = $('#' + syncedImagesId).data('embed');
 
@@ -44,7 +44,7 @@ $(document).ready(function () {
         return false;
     }
 
-    return String(megaNumber + parsedId);
+    return String(initialFakeId + parsedId);
   }
 
   function thumbPrefix(id) {

--- a/src/views/js/cappasity16.js
+++ b/src/views/js/cappasity16.js
@@ -1,21 +1,93 @@
 /**
 {LICENSE_PLACEHOLDER}
 */
-
 $(document).ready(function () {
   var settingsId = 'cappasity-player-settings';
-  var playerUrl = 'https://{API_HOST_PLACEHOLDER}/api/player';
+  var syncedImagesId = 'cappasity-synced-images';
+  var playerUrl = 'https://api.cappasity3d.com/api/player';
   var previewUrl = 'https://{API_HOST_PLACEHOLDER}/api/files/preview/';
   var previewFilters = 'w80-h80-cpad-bffffff';
   var iconHref = '/modules/cappasity3d/views/img/logo-3d.jpg';
   var iconBigHref = '/modules/cappasity3d/views/img/logo-3d-thickbox.jpg';
-
+  var megaNumber = 100000000;
   var playerSettings = $('#' + settingsId).data('embed');
-  var $cappasityLinks = $('a[title^="cappasity:"]');
+  var syncedImages = $('#' + syncedImagesId).data('embed');
+
+  if (!playerSettings || !syncedImages || !syncedImages.length) {
+    return;
+  }
+
+  var syncedImagesIds = syncedImages.map(idProperty);
+  var mockedImagesIds = syncedImagesIds.map(makeMockedImageId);
+  var cappasityThumbIds = mockedImagesIds.map(thumbPrefix);
+
+  var thumbIdsToModelIds = Object.create(null);
+  syncedImages.reduce(function indexWithThumbId(acc, syncedImage) {
+      var originalId = idProperty(syncedImage);
+      var thumbId = thumbPrefix(makeMockedImageId(originalId));
+      acc[thumbId] = cappasityIdProperty(syncedImage);
+
+      return acc;
+  }, thumbIdsToModelIds);
+
+  function idProperty(image) {
+    return image['id'];
+  }
+
+  function cappasityIdProperty(image) {
+    return image['cappasity_id'];
+  }
+
+  function makeMockedImageId(cappasityImageId) {
+    var parsedId = parseInt(cappasityImageId, 10);
+    if (isNaN(parsedId)) {
+        return false;
+    }
+
+    return String(megaNumber + parsedId);
+  }
+
+  function thumbPrefix(id) {
+    return 'thumb_' + id;
+  }
+
+  function makeEmbedId(cappasityId) {
+    return 'cappasity:' + cappasityId;
+  }
+
+  function findThumbImageId(thumbLinkEl) {
+    var thumbImgEl = thumbLinkEl.querySelector('img');
+
+    if (thumbImgEl === null) {
+      throw new Error('Thumbnail link was expected to have thumbnail image inside');
+    }
+
+    return thumbImgEl.getAttribute('id');
+  }
+
+  function isCappasityLink(thumbLinkEl) {
+    var id = findThumbImageId(thumbLinkEl);
+
+    return cappasityThumbIds.indexOf(id) !== -1;
+  }
+
+  function filterCappasityLinks(_, el) { return isCappasityLink(el); }
+
+  function getModelIdByThumbId(thumbId) {
+    var cappasityId = thumbIdsToModelIds[thumbId];
+
+    if (cappasityId === undefined) {
+      throw Error('Target thumb id not found in haystack: ' + thumbId);
+    }
+
+    return cappasityId;
+  }
+
   var $thumbContainer = $('#thumbs_list');
   var $thumbList = $('ul#thumbs_list_frame');
+  var $cappasityLinks = $thumbList.find('a').filter(filterCappasityLinks);
 
-  if (!playerSettings || !$cappasityLinks.length) {
+  if (!$cappasityLinks.length || !$thumbList.length) {
     return;
   }
 
@@ -23,137 +95,150 @@ $(document).ready(function () {
   var $embedsArr = [];
   var $iframesArr = [];
 
-  if ($thumbList.length) {
-    $cappasityLinks.each(function mapLinks(_, el) {
-      var title = el.getAttribute('title');
-      var modelId = title.replace('cappasity:', '');
-      el.querySelector('img').setAttribute('src', iconHref);
+  $cappasityLinks.each(function mapLinks(_, el) {
+    var thumbEl = el.querySelector('img');
+    var thumbId = thumbEl.getAttribute('id');
+    var modelId = getModelIdByThumbId(thumbId);
+    var embedId = makeEmbedId(modelId);
 
-      var $iframe = $('<iframe />', {
-        src: playerUrl + '/' + modelId + '/embedded?' + $.param(playerSettings),
-        frameborder: 0,
-        allowfullscreen: true
-      });
-      $iframe.attr('width', playerSettings.width);
-      $iframe.attr('height', playerSettings.height);
+    thumbEl.setAttribute('src', iconHref);
+    el.querySelector('img').setAttribute('src', iconHref);
 
-      var $embed = $('<div />', { id: title })
-        .append($iframe)
-        .css({
-          position: 'absolute',
-          top: 0,
-          bottom: 0,
-          left: 0,
-          right: 0,
-          zIndex: -1
-        });
+    var $iframe = $('<iframe />', {
+      src: playerUrl + '/' + modelId + '/embedded?' + $.param(playerSettings),
+      frameborder: 0,
+      allowfullscreen: true
+    });
+    $iframe.attr('width', playerSettings.width);
+    $iframe.attr('height', playerSettings.height);
 
-      $(el).attr({
-        href: iconBigHref,
-        'data-fancybox-type': 'iframe',
-        'data-fancybox-width': $iframe.attr('width'),
-        'data-fancybox-height': $iframe.attr('height'),
-        'data-fancybox-href': $iframe.attr('src')
+    var $embed = $('<div />', { id: embedId })
+      .append($iframe)
+      .css({
+        position: 'absolute',
+        top: 0,
+        bottom: 0,
+        left: 0,
+        right: 0,
+        zIndex: -1
       });
 
-      if (!$embeds[title]) {
-        $embeds[title] = $embed;
-        $embedsArr.push($embed);
-        $iframesArr.push($iframe);
+    $(el).attr({
+      href: iconBigHref,
+      'data-fancybox-type': 'iframe',
+      'data-fancybox-width': $iframe.attr('width'),
+      'data-fancybox-height': $iframe.attr('height'),
+      'data-fancybox-href': $iframe.attr('src')
+    });
+
+    if (!$embeds[embedId]) {
+      $embeds[embedId] = $embed;
+      $embedsArr.push($embed);
+      $iframesArr.push($iframe);
+    }
+  });
+
+  var $viewFullSize = $('#view_full_size').eq(0);
+  var hasBigPic = $('#bigpic, #view_full_size .jqzoom').eq(0).length;
+
+  if ($viewFullSize.length) {
+    $viewFullSize.css({ display: 'block', position: 'relative' });
+    $embedsArr.forEach(function appendEmbed($embed) {
+      $viewFullSize.append($embed);
+    });
+  }
+
+  function getTargetEmbedId($el) {
+    if (!isCappasityLink($el[0])) {
+      return $el.attr('title');
+    }
+
+    var $img = $el.find('img').eq(0);
+    var thumbId = $img.attr('id');
+    var modelId = getModelIdByThumbId(thumbId);
+    return makeEmbedId(modelId);
+  }
+
+  function displayImage($el) {
+    var targetEmbedId = getTargetEmbedId($el);
+    var $bigPic = $('#bigpic, #view_full_size .zoomPad').eq(0);
+
+    function setDimensions() {
+      var width = $bigPic.css('width');
+      var height = $bigPic.css('height');
+
+      $iframesArr.forEach(function ($iframe) {
+        $iframe.attr('width', width);
+        $iframe.attr('height', height);
+      })
+    }
+
+    if ($bigPic.length) {
+      if (!$bigPic.width() || !$bigPic.height()) {
+        var oldOnload = $bigPic.get(0).onload;
+
+        $bigPic.get(0).onload = function () {
+          setDimensions();
+
+          $bigPic.get(0).onload = oldOnload;
+          if (typeof oldOnload === 'function') {
+            oldOnload.apply(this, arguments);
+          }
+        };
+      } else {
+        setDimensions();
+      }
+
+      $embedsArr.forEach(function mapEmbeds($embed) {
+        $embed.css({ zIndex: targetEmbedId === $embed.attr('id') ? 1 : -1 })
+      })
+    }
+  }
+
+  if (jqZoomEnabled) {
+    $cappasityLinks.each(function processRel(_, el) {
+      var rel = el.getAttribute('rel');
+      el.setAttribute('href', 'javascript:void(0);');
+
+      if (rel) {
+        try {
+          var relObj = eval("(" + $.trim(rel) + ")");
+          var newRelStr = "{gallery: '" + relObj.gallery + "', smallimage: '" + iconHref + "', largeimage: '" + iconBigHref + "'}";
+          el.setAttribute('rel', newRelStr);
+        } catch (e) {}
       }
     });
 
-    var $viewFullSize = $('#view_full_size').eq(0);
-    var hasBigPic = $('#bigpic, #view_full_size .jqzoom').eq(0).length;
 
-    if ($viewFullSize.length) {
-      $viewFullSize.css({ display: 'block', position: 'relative' });
-      $embedsArr.forEach(function appendEmbed($embed) {
-        $viewFullSize.append($embed);
-      });
-    }
+    $('.jqzoom').each(function() {
+      var api = $(this).data('jqzoom');
 
-    function displayImage($el) {
-      var title = $el && $el.attr('title');
-      var $bigPic = $('#bigpic, #view_full_size .zoomPad').eq(0);
+      if (!api || !api.swapimage) return;
 
-      function setDimensions() {
-        var width = $bigPic.css('width');
-        var height = $bigPic.css('height');
+      var oldSwapImage = api.swapimage;
 
-        $iframesArr.forEach(function ($iframe) {
-          $iframe.attr('width', width);
-          $iframe.attr('height', height);
-        })
-      }
-
-      if ($bigPic.length) {
-        if (!$bigPic.width() || !$bigPic.height()) {
-          var oldOnload = $bigPic.get(0).onload;
-
-          $bigPic.get(0).onload = function () {
-            setDimensions();
-
-            $bigPic.get(0).onload = oldOnload;
-            if (typeof oldOnload === 'function') {
-              oldOnload.apply(this, arguments);
-            }
-          };
-        } else {
-          setDimensions();
-        }
-
-        $embedsArr.forEach(function mapEmbeds($embed) {
-          $embed.css({ zIndex: title === $embed.attr('id') ? 1 : -1 })
-        })
-      }
-    }
-
-    if (jqZoomEnabled) {
-      $cappasityLinks.each(function processRel(_, el) {
-        var rel = el.getAttribute('rel');
-        el.setAttribute('href', 'javascript:void(0);');
-
-        if (rel) {
-          try {
-            var relObj = eval("(" + $.trim(rel) + ")");
-            var newRelStr = "{gallery: '" + relObj.gallery + "', smallimage: '" + iconHref + "', largeimage: '" + iconBigHref + "'}";
-            el.setAttribute('rel', newRelStr);
-          } catch (e) {}
-        }
-      });
-
-
-      $('.jqzoom').each(function() {
-        var api = $(this).data('jqzoom');
-
-        if (!api || !api.swapimage) return;
-
-        var oldSwapImage = api.swapimage;
-
-        api.swapimage = function(link) {
-          var args = [].slice.call(arguments);
-          displayImage($(link));
-          oldSwapImage.apply(this, args);
-        };
-      });
-
-      return;
-    }
-
-    var oldDisplayImage = window.displayImage;
-
-    if(oldDisplayImage && $viewFullSize.length && hasBigPic) {
-      window.displayImage = function ($el) {
+      api.swapimage = function(link) {
         var args = [].slice.call(arguments);
-
-        displayImage($el);
-        oldDisplayImage.apply(window, args);
+        displayImage($(link));
+        oldSwapImage.apply(this, args);
       };
-    }
+    });
 
-    refreshProductImages(0);
-    $thumbContainer.trigger('goto', 0);
-    displayImage($cappasityLinks.eq(0));
+    return;
   }
+
+  var oldDisplayImage = window.displayImage;
+
+  if(oldDisplayImage && $viewFullSize.length && hasBigPic) {
+    window.displayImage = function ($el) {
+      var args = [].slice.call(arguments);
+
+      displayImage($el);
+      oldDisplayImage.apply(window, args);
+    };
+  }
+
+  refreshProductImages(0);
+  $thumbContainer.trigger('goto', 0);
+  displayImage($cappasityLinks.eq(0));
 });

--- a/src/views/js/cappasity17.js
+++ b/src/views/js/cappasity17.js
@@ -109,6 +109,10 @@ $(document).ready(function() {
     return el.getAttribute('data-image-large-src');
   }
 
+  /**
+   * @param previewSrc Ex.: https://api.cappasity.com/api/files/preview/uname/w800-h800-cpad/dd596de4-ae2b-4d66-a023-242ca7d86b51.jpeg
+   * @returns {*}
+   */
   function parseCappasityId(previewSrc) {
     if (typeof previewSrc !== 'string' || !previewSrc.length) {
       throw new Error('Preview src expected to be a string');

--- a/src/views/js/cappasity17.js
+++ b/src/views/js/cappasity17.js
@@ -42,12 +42,8 @@ $(document).ready(function() {
   var $iframesModal = {};
   var $iframesModalArr = [];
 
-  function thumbId(alt) {
-    return 'thumbCpst:' + alt;
-  }
-
-  function modalId(alt) {
-    return 'modalCpst:' + alt;
+  function modalId(cappasityId) {
+    return 'modalCpst:' + cappasityId;
   }
 
   function getBigImageContainer() {
@@ -67,10 +63,9 @@ $(document).ready(function() {
     return $img.parent();
   }
 
-  function generateIframe(id, alt, settings) {
+  function generateIframe(cappasityId, settings) {
     return $('<iframe />', {
-      id: thumbId(alt),
-      src: playerUrl + '/' + id + '/embedded?' + $.param(settings),
+      src: playerUrl + '/' + cappasityId + '/embedded?' + $.param(settings),
       frameborder: 0,
       allowfullscreen: true,
       height: '100%',
@@ -83,8 +78,8 @@ $(document).ready(function() {
     });
   }
 
-  function generateModalIframe(id, alt, settings) {
-    return $('<div />', { id: modalId(alt) })
+  function generateModalIframe(cappasityId, settings) {
+    return $('<div />', { id: modalId(cappasityId) })
       .css({
         display: 'none',
         position: 'absolute',
@@ -95,7 +90,7 @@ $(document).ready(function() {
         zIndex: 1
       })
       .append($('<iframe />', {
-        src: playerUrl + '/' + id + '/embedded?' + $.param(settings),
+        src: playerUrl + '/' + cappasityId + '/embedded?' + $.param(settings),
         frameborder: 0,
         allowfullscreen: true,
         height: '100%',
@@ -110,46 +105,79 @@ $(document).ready(function() {
 
   }
 
-  function handleThumb(el, settings) {
-    var alt = el.getAttribute('alt');
-    var modelId = alt.replace('cappasity:', '');
+  function getImageSrcAttr(el) {
+    return el.getAttribute('data-image-large-src');
+  }
 
-    if (!$iframes[alt]) {
-      $iframesArr.push($iframes[alt] = generateIframe(modelId, alt, settings));
+  function parseCappasityId(previewSrc) {
+    if (typeof previewSrc !== 'string' || !previewSrc.length) {
+      throw new Error('Preview src expected to be a string');
     }
 
-    if (!$iframesModal[alt]) {
-      $iframesModalArr.push($iframesModal[alt] = generateModalIframe(modelId, alt, settings));
+    return previewSrc.split('/').pop().split('.').shift();
+  }
+
+  function hasCappasityPreviewSrc(el) {
+    var previewSrc = getImageSrcAttr(el);
+
+    return (previewSrc && previewSrc.indexOf('cappasity') !== -1);
+  }
+
+  function isCappasityThumb(el) {
+    return hasCappasityPreviewSrc(el);
+  }
+
+  function getCappasityId(el) {
+      var previewSrc = getImageSrcAttr(el);
+
+      if (!previewSrc || previewSrc.indexOf('cappasity') === -1) {
+        throw new Error('Element is expected to be Cappasity thumbnail');
+      }
+
+      return parseCappasityId(previewSrc);
+  }
+
+  function handleThumb(el, settings) {
+    var cappasityId = getCappasityId(el);
+
+    if (!$iframes[cappasityId]) {
+      $iframesArr.push($iframes[cappasityId] = generateIframe(cappasityId, settings));
+    }
+
+    if (!$iframesModal[cappasityId]) {
+      $iframesModalArr.push($iframesModal[cappasityId] = generateModalIframe(cappasityId, settings));
     }
   }
 
   function handleThumbClick(ev) {
-    var alt = ev.target.getAttribute('alt');
-    var $iframe = $iframes[alt];
-    var $bigImgContainer = getBigImageContainer();
-
-    if ($iframe) {
-      if (!$bigImgContainer.find($iframe).length) {
-        $bigImgContainer.prepend($iframe);
-      }
-
-      $iframesArr.forEach(function ($el) {
-        if ($el === $iframe) {
-          $el.css({ display: 'block' });
-        } else {
-          $el.css({ display: 'none' });
-        }
-      });
-    } else {
+    if (!isCappasityThumb(ev.target)) {
       $iframesArr.forEach(function ($el) {
         $el.css({ display: 'none' });
       });
+
+      return;
     }
+
+    var targetEmbedId = getCappasityId(ev.target);
+    var $iframe = $iframes[targetEmbedId];
+    var $bigImgContainer = getBigImageContainer();
+
+    if (!$bigImgContainer.find($iframe).length) {
+      $bigImgContainer.prepend($iframe);
+    }
+
+    $iframesArr.forEach(function ($el) {
+      if ($el === $iframe) {
+        $el.css({ display: 'block' });
+      } else {
+        $el.css({ display: 'none' });
+      }
+    });
   }
 
   function handleModalThumbClick(ev) {
-    var alt = ev.target.getAttribute('alt');
-    var $iframe = $iframesModal[alt];
+    var targetEmbedId = getCappasityId(ev.target);
+    var $iframe = $iframesModal[targetEmbedId];
 
     if ($iframe) {
       requestAnimationFrame(function () {
@@ -177,7 +205,7 @@ $(document).ready(function() {
   }
 
   function reset() {
-    $iframes = {}
+    $iframes = {};
     $iframesArr = [];
 
     $iframesModal = {};
@@ -189,7 +217,7 @@ $(document).ready(function() {
     var $modalImgContainer = getModalImageContainer();
 
     var playerSettings = $('#' + settingsId).data('embed');
-    var $cappasityThumbs = $('img.js-thumb[alt^="cappasity:"]');
+    var $cappasityThumbs = $('img.js-thumb[data-image-large-src*="cappasity"]');
 
     if (!playerSettings || !$cappasityThumbs.length) {
       return;
@@ -197,9 +225,10 @@ $(document).ready(function() {
 
     $cappasityThumbs.each(function (_, el) { handleThumb(el, playerSettings )});
 
-    var alt = $('img.js-thumb.selected').eq(0).attr('alt');
+    var targetThumb = $('img.js-thumb.selected')[0];
     $iframesArr.forEach(function ($iframe) {
-      $iframe.css({ display: $iframe === $iframes[alt] ? 'display' : 'none' });
+      var isTargetIframe = isCappasityThumb(targetThumb) && ($iframe === $iframes[getCappasityId(targetThumb)]);
+      $iframe.css({ display: isTargetIframe ? 'block' : 'none' });
       if (!$bigImgContainer.find($iframe).length) {
         $bigImgContainer.prepend($iframe);
       }

--- a/src/views/templates/front/synced-images.tpl
+++ b/src/views/templates/front/synced-images.tpl
@@ -1,0 +1,5 @@
+{*
+{LICENSE_PLACEHOLDER}
+*}
+<div id="cappasity-synced-images"
+     data-embed="{$syncedImages|@json_encode|escape:'htmlall':'UTF-8'}"></div>


### PR DESCRIPTION
1.6 integration uses matching fake image IDs, which is a sum of a big constant number and a respective real synced image ID.
Since 1.7 does not expose image ID, matching logic there is different and relies on data-large-image-src thumbnail atribute, since it contains the link to a cappasity preview with file ID in it.
